### PR TITLE
Fix Apple Appstore warning ITMS-90683: Missing Purpose String in Info…

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -25,7 +25,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Die App benötigt Zugriff auf den Standort um die aktuelle Position anzuzeigen.</string>
+	<string>Die App benötigt Zugriff auf den Standort um die aktuelle Position auf der Karte anzuzeigen.</string>
+    <key>NSLocationAlwaysUsageDescription</key>
+    <string>Die App benötigt Zugriff auf den Standort um die aktuelle Position auf der Karte anzuzeigen.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.0.2+2
+version: 0.0.2+3
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
….plist