### PR TITLE
Cache für Kartendaten

### DIFF
--- a/lib/ui/about/settings_screen.dart
+++ b/lib/ui/about/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:munich_ways/ui/map/flutter_map/map_cache_store.dart';
 import 'package:munich_ways/ui/map/munichways_api.dart';
 import 'package:munich_ways/ui/side_drawer.dart';
 
@@ -10,6 +11,7 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
       GlobalKey<ScaffoldMessengerState>();
+  Future<String> mapCacheStoreStatsFuture = MapCacheStore().getStats();
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +37,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   MunichwaysApi().emptyCache();
                 },
               ),
+              FutureBuilder<String>(
+                  future: mapCacheStoreStatsFuture,
+                  builder: (context, snapshot) {
+                    String stats;
+                    if (snapshot.hasData) {
+                      stats = snapshot.data!;
+                    } else {
+                      stats = "Lade ...";
+                    }
+                    ;
+                    return ListTile(
+                      title: Text('Kartencache löschen'),
+                      subtitle: Text(stats),
+                      trailing: Icon(Icons.delete),
+                      onTap: () async {
+                        await MapCacheStore().emptyCache();
+                        setState(() {
+                          mapCacheStoreStatsFuture = MapCacheStore().getStats();
+                        });
+                      },
+                    );
+                  }),
             ],
           ).toList(),
         ),

--- a/lib/ui/map/flutter_map/map_cache_store.dart
+++ b/lib/ui/map/flutter_map/map_cache_store.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
+import 'package:dio_cache_interceptor_file_store/dio_cache_interceptor_file_store.dart';
+import 'package:munich_ways/common/logger_setup.dart';
+import 'package:path_provider/path_provider.dart';
+
+class MapCacheStore {
+  static CacheStore? _cacheStore = null;
+
+  Future<CacheStore> getMapCacheStore() async {
+    if (_cacheStore != null) {
+      return Future.value(_cacheStore);
+    }
+    _cacheStore = FileCacheStore(await _getMapCachePath());
+    return Future.value(_cacheStore);
+  }
+
+  Future<String> _getMapCachePath() async {
+    final tempDirForCaches = await getTemporaryDirectory();
+    return '${tempDirForCaches.path}${Platform.pathSeparator}MapTiles';
+  }
+
+  Future<String> getStats() async {
+    CacheStore cacheStore = await getMapCacheStore();
+    var path = await _getMapCachePath();
+
+    log.d("cache Path: $path");
+    int fileNum = 0;
+    int totalSize = 0;
+    var dir = Directory(path);
+    try {
+      if (dir.existsSync()) {
+        dir
+            .listSync(recursive: true, followLinks: false)
+            .forEach((FileSystemEntity entity) {
+          if (entity is File) {
+            log.d("file ${entity.path}");
+            fileNum++;
+            totalSize += entity.lengthSync();
+          }
+        });
+      }
+    } catch (e) {
+      print(e.toString());
+    }
+    log.d('FileNum: $fileNum, totalSize: ${totalSize / 1024} KB');
+
+    var list = await cacheStore.getFromPath(RegExp('https:'));
+    for (var element in list) {
+      log.d(
+          "${element.url} ${element.expires?.toIso8601String()} ${element.maxStale?.toIso8601String()}");
+    }
+    return "Gesamt: ${(totalSize / 1024 / 1024).toStringAsFixed(2)} MB";
+  }
+
+  Future<void> emptyCache() async {
+    CacheStore cacheStore = await getMapCacheStore();
+    await cacheStore.clean(
+        priorityOrBelow: CachePriority.high, staleOnly: false);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "417e2a6f9d83ab396ec38ff4ea5da6c254da71e4db765ad737a42af6930140b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.3"
+  dio_cache_interceptor:
+    dependency: transitive
+    description:
+      name: dio_cache_interceptor
+      sha256: a89166e6fb9c90a4bf2b7f20b5c055087969bc445ced3282e32505543e296e0f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.2"
+  dio_cache_interceptor_file_store:
+    dependency: "direct main"
+    description:
+      name: dio_cache_interceptor_file_store
+      sha256: c84eefeeb725b44e96d6cb300e86e898bd5026dcf3d468737a8ec209b967fc73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
   equatable:
     dependency: "direct main"
     description:
@@ -158,6 +182,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.1"
+  flutter_map_cache:
+    dependency: "direct main"
+    description:
+      name: flutter_map_cache
+      sha256: f8d178eff9c2e94b6206411af30efcda2bf94bcef21e0592a8773debdeb130c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_map: ^6.0.0
+  flutter_map_cache: ^1.3.0
+  dio_cache_interceptor_file_store: ^1.2.2 # file system cache for flutter_map_cache
   provider: ^6.0.4
   http: ^1.0.0
   http_interceptor: ^2.0.0-beta.7


### PR DESCRIPTION
Solves #76 

Fügt einen Cache für die Kartendaten hinzu. Die Kartendaten werden beim ersten Aufrufen der Kartenabschnitte heruntergeladen und im Anschluss auf dem Gerät 30 Tage gecached. Das sollte den Datenverbrauch senken. Den Zeitraum von 30 Tagen kann man beliebig einstellen, hab mich an dem im Ticket vorgeschlagenen Monat orientiert.

Man kann den Kartencache in den Einstellungen auch manuell löschen, wenn man will, sollte aber eigentlich nur zum Testen notwendig sein.

![simulator_screenshot_ABB308DB-A1A1-4101-A15C-AAE6A130F9DF](https://github.com/MunichWays/munich-ways-app/assets/1040402/d7078c0b-28aa-4783-9fdb-6a21f8befb5f)


Was meinst Du? @thomas-munichways 