### PR TITLE
Fix unnbeabsichtiges Rotieren der Karte

### DIFF
--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -206,10 +206,8 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
                             mapController: mapController,
                             options: MapOptions(
                               interactionOptions: InteractionOptions(
-                                flags: InteractiveFlag.drag |
-                                    InteractiveFlag.pinchZoom |
-                                    InteractiveFlag.rotate,
-                              ),
+                                  flags: InteractiveFlag.all,
+                                  enableMultiFingerGestureRace: true),
                               initialCenter: _stachus,
                               initialZoom: 15,
                               maxZoom: 18,


### PR DESCRIPTION
Beim Zoomen der Karte mit einer Pinchgeste wurde bisher immer die Karte auch unbeabsichtigter Weise mit rotiert.

Durch die Änderung hier wird das verhindert. Man kann jetzt mit zwei Fingern Zoomen, dann wir nicht mehr gleichzeitig rotiert. Und umgekehrt, wenn man nur die zwei Finger dreht um zu rotieren wird nicht gleichzeitig gezoomt.