### PR TITLE
Bugfix Ansage-in-Standby und Suchabsturz

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <!-- workaround for PlatformException - missing Wake lock permission -->
     <!-- see https://github.com/flutter/flutter/issues/42451 or https://github.com/flutter/flutter/issues/59063 for tickets -->

--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -81,6 +81,8 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
   bool _featureTapHandlerAttached = false;
   Circle? _destinationCircle;
   StreamSubscription<Position>? _locationSubscription;
+  bool _locationStreamUsesForegroundService = false;
+  int _locationStreamGeneration = 0;
   Position? _latestPosition;
   Position? _pendingPosition;
   bool _locationRenderRunning = false;
@@ -220,6 +222,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     }
     unawaited(_flutterTts.stop());
     model.clearDestination();
+    unawaited(_updateLocationStream(model));
   }
 
   Future<void> _syncCompassBearingFromMap() async {
@@ -630,7 +633,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
                             await model.onPressLocationBtn();
                             if (!mounted) return;
                             await _applyNativeLocationTracking(model);
-                            _updateLocationStream(model);
+                            await _updateLocationStream(model);
                           },
                           navigationBar: model.destination == null
                               ? null
@@ -769,12 +772,29 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     );
   }
 
-  LocationSettings _locationSettings() {
+  LocationSettings _locationSettings({
+    required bool keepNavigationAliveInBackground,
+  }) {
     if (defaultTargetPlatform == TargetPlatform.android) {
       return AndroidSettings(
         accuracy: LocationAccuracy.bestForNavigation,
         distanceFilter: 0,
-        intervalDuration: const Duration(milliseconds: 250),
+        intervalDuration: const Duration(seconds: 1),
+        foregroundNotificationConfig: keepNavigationAliveInBackground
+            ? ForegroundNotificationConfig(
+                notificationTitle: context.l10n.isEnglish
+                    ? 'MunichWays navigation'
+                    : 'MunichWays Navigation',
+                notificationText: context.l10n.isEnglish
+                    ? 'Voice guidance and location remain active'
+                    : 'Sprachansagen und Standort bleiben aktiv',
+                notificationChannelName:
+                    context.l10n.isEnglish ? 'Navigation' : 'Navigation',
+                enableWakeLock: true,
+                setOngoing: true,
+                color: AppColors.mapAccentColor,
+              )
+            : null,
       );
     }
     return const LocationSettings(
@@ -783,16 +803,34 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     );
   }
 
-  void _updateLocationStream(MapScreenViewModel model) {
+  Future<void> _updateLocationStream(MapScreenViewModel model) async {
+    final generation = ++_locationStreamGeneration;
     if (model.locationState == LocationState.NOT_AVAILABLE) {
-      _locationSubscription?.cancel();
+      final subscription = _locationSubscription;
       _locationSubscription = null;
+      _locationStreamUsesForegroundService = false;
+      await subscription?.cancel();
       return;
     }
-    if (_locationSubscription != null) return;
+    final shouldUseForegroundService =
+        defaultTargetPlatform == TargetPlatform.android &&
+            model.navigationStarted;
+    if (_locationSubscription != null &&
+        _locationStreamUsesForegroundService == shouldUseForegroundService) {
+      return;
+    }
+    final previousSubscription = _locationSubscription;
+    if (previousSubscription != null) {
+      _locationSubscription = null;
+      await previousSubscription.cancel();
+      if (!mounted || generation != _locationStreamGeneration) return;
+    }
+    _locationStreamUsesForegroundService = shouldUseForegroundService;
 
     _locationSubscription = Geolocator.getPositionStream(
-      locationSettings: _locationSettings(),
+      locationSettings: _locationSettings(
+        keepNavigationAliveInBackground: shouldUseForegroundService,
+      ),
     ).listen(
       (position) {
         _latestPosition = position;
@@ -965,7 +1003,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     await WidgetsBinding.instance.endOfFrame;
     if (!mounted) return;
     await _applyNativeLocationTracking(model);
-    _updateLocationStream(model);
+    await _updateLocationStream(model);
   }
 
   Future<void> _refreshRouteAndResumeNavigation(
@@ -984,7 +1022,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     await model.onPressLocationBtn(permissionCheck: permissionCheck);
     if (!mounted) return;
     await _applyNativeLocationTracking(model);
-    _updateLocationStream(model);
+    await _updateLocationStream(model);
     final cachedPosition = await Geolocator.getLastKnownPosition();
     if (!mounted || cachedPosition == null) return;
     _latestPosition = cachedPosition;
@@ -997,7 +1035,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     await model.refreshCurrentLocationFix();
     if (!mounted) return;
     await _applyNativeLocationTracking(model);
-    _updateLocationStream(model);
+    await _updateLocationStream(model);
   }
 
   bool _isValidCoordinate(double latitude, double longitude) {

--- a/lib/ui/map/voice_guidance.dart
+++ b/lib/ui/map/voice_guidance.dart
@@ -12,7 +12,7 @@ class VoiceGuidance {
     this.approachDistanceMeters = 60,
     this.nowDistanceMeters = 15,
     this.maximumRouteDistanceMeters = 25,
-    this.arrivalDistanceMeters = 25,
+    this.arrivalDistanceMeters = 20,
     this.lookAheadSeconds = 2,
     this.maximumLookAheadMeters = 15,
     this.speechLeadSeconds = 2,

--- a/lib/ui/place_search/place_search_screen_model.dart
+++ b/lib/ui/place_search/place_search_screen_model.dart
@@ -88,26 +88,13 @@ class PlaceSearchScreenViewModel extends ChangeNotifier {
     _notifyListeners();
 
     try {
-      final correction = await streetCorrector.correct(query);
-      final correctedSearchQuery = correction?.query ?? query;
-      List<Place> newPlaces;
-      try {
-        newPlaces = await api.search(
-          correctedSearchQuery,
-          searchCenter: searchCenter,
-        );
-        resultsFromNominatim = false;
-      } catch (error, stackTrace) {
-        log.w(
-          'Geoapify search failed, trying Nominatim fallback',
-          error: error,
-          stackTrace: stackTrace,
-        );
-        newPlaces = await fallbackApi.search(
-          correctedSearchQuery,
-          searchCenter: searchCenter,
-        );
-        resultsFromNominatim = true;
+      var newPlaces = await _searchProviders(query);
+      MunichStreetCorrection? correction;
+      if (newPlaces.isEmpty) {
+        correction = await streetCorrector.correct(query);
+        if (correction != null && correction.query != query) {
+          newPlaces = await _searchProviders(correction.query);
+        }
       }
       if (searchSequence != _searchSequence) {
         return;
@@ -127,6 +114,29 @@ class PlaceSearchScreenViewModel extends ChangeNotifier {
         loading = false;
         _notifyListeners();
       }
+    }
+  }
+
+  Future<List<Place>> _searchProviders(String query) async {
+    try {
+      final result = await api.search(
+        query,
+        searchCenter: searchCenter,
+      );
+      resultsFromNominatim = false;
+      return result;
+    } catch (error, stackTrace) {
+      log.w(
+        'Geoapify search failed, trying Nominatim fallback',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      final result = await fallbackApi.search(
+        query,
+        searchCenter: searchCenter,
+      );
+      resultsFromNominatim = true;
+      return result;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.1.7+44
+version: 3.1.7+45
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/ui/map/voice_guidance_test.dart
+++ b/test/ui/map/voice_guidance_test.dart
@@ -218,4 +218,26 @@ void main() {
     );
     expect(guidance.update(end, english: false), isNull);
   });
+
+  test('does not announce arrival outside the 20 metre destination radius', () {
+    final guidance = VoiceGuidance();
+    guidance.setRoute(CycleRoute(
+      const [start, end],
+      170,
+      40,
+      maneuvers: const [
+        RouteManeuver(location: end, type: 'arrive'),
+      ],
+    ));
+
+    const aboutTwentyFiveMetresBeforeEnd = LatLng(48.14127, 11.5700);
+    expect(
+      guidance.update(aboutTwentyFiveMetresBeforeEnd, english: false),
+      isNull,
+    );
+    expect(
+      guidance.update(end, english: false),
+      'Sie haben das Ziel erreicht.',
+    );
+  });
 }

--- a/test/ui/place_search/place_search_body_test.dart
+++ b/test/ui/place_search/place_search_body_test.dart
@@ -67,6 +67,23 @@ class DelayedGeoapifyApi extends GeoapifyApi {
       completer.future;
 }
 
+class SuccessfulGeoapifyApi extends GeoapifyApi {
+  SuccessfulGeoapifyApi() : super(apiKey: 'test');
+
+  @override
+  Future<List<Place>> search(String query, {LatLng? searchCenter}) async => [
+        Place(query, const LatLng(48.137, 11.576)),
+      ];
+}
+
+class HangingStreetCorrector extends MunichStreetCorrector {
+  HangingStreetCorrector() : super.fromStreetNames(const []);
+
+  @override
+  Future<MunichStreetCorrection?> correct(String query) =>
+      Completer<MunichStreetCorrection?>().future;
+}
+
 void main() {
   test('ignores recent searches that finish after disposal', () async {
     final store = DelayedRecentSearchesStore();
@@ -126,6 +143,19 @@ void main() {
     expect(model.errorMsg, isNull);
     expect(model.places.single.displayName, 'Marienplatz');
     expect(model.resultsFromNominatim, isTrue);
+  });
+
+  test('shows normal results without waiting for typo correction', () async {
+    final model = PlaceSearchScreenViewModel(
+      recentSearchesRepo: FakeRecentSearchesStore([]),
+      api: SuccessfulGeoapifyApi(),
+      streetCorrector: HangingStreetCorrector(),
+    );
+
+    await model.startSearch('Marien');
+
+    expect(model.loading, isFalse);
+    expect(model.places.single.displayName, 'Marien');
   });
 
   testWidgets('shows map selection without redundant search hint',


### PR DESCRIPTION
**Sprachansagen und Standby-Navigation bleiben aktiv.**
Das Standortintervall ist jetzt von 250 Millisekunden auf 1 Sekunde erhöht. GPS und Navigation benötigen dadurch weniger Rechenleistung und Akku.

„Ziel erreicht“ wurde bisher innerhalb von 25 Metern ausgelöst. Der Radius beträgt jetzt 20 Meter. Das ist präziser, lässt aber noch ausreichend Spielraum für GPS-Ungenauigkeit.
Die Suche wurde ab fünf Zeichen durch die lokale Tippfehlerkorrektur ausgebremst. Jetzt läuft zuerst die normale Suche. Die Korrektur der Münchner Straßennamen wird nur noch verwendet, wenn keine normalen Ergebnisse gefunden wurden.