### PR TITLE
bugfix_Nav_notification

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- workaround for PlatformException - missing Wake lock permission -->
     <!-- see https://github.com/flutter/flutter/issues/42451 or https://github.com/flutter/flutter/issues/59063 for tickets -->

--- a/android/app/src/main/kotlin/com/munichways/munich_ways/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/munichways/munich_ways/MainActivity.kt
@@ -1,6 +1,60 @@
 package com.munichways.munich_ways
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
+    private var notificationPermissionResult: MethodChannel.Result? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            NOTIFICATION_PERMISSION_CHANNEL
+        ).setMethodCallHandler { call, result ->
+            if (call.method != "request") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                result.success(true)
+                return@setMethodCallHandler
+            }
+            if (notificationPermissionResult != null) {
+                result.success(false)
+                return@setMethodCallHandler
+            }
+            notificationPermissionResult = result
+            requestPermissions(
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                NOTIFICATION_PERMISSION_REQUEST
+            )
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode != NOTIFICATION_PERMISSION_REQUEST) return
+        notificationPermissionResult?.success(
+            grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED
+        )
+        notificationPermissionResult = null
+    }
+
+    companion object {
+        private const val NOTIFICATION_PERMISSION_CHANNEL =
+            "com.munichways.app/notification_permission"
+        private const val NOTIFICATION_PERMISSION_REQUEST = 4102
+    }
 }

--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart' as latlong2;
@@ -40,6 +41,8 @@ class MapScreen extends StatefulWidget {
 
 class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
   static const latlong2.LatLng _stachus = latlong2.LatLng(48.14, 11.5652);
+  static const _notificationPermissionChannel =
+      MethodChannel('com.munichways.app/notification_permission');
 
   static const _kNetworkSourceId = 'munichways_radlnetz';
   static const _kNetworkLayerVisibleGesamtId =
@@ -993,6 +996,8 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
 
     final started = await model.startNavigation();
     if (!mounted || !started) return;
+    await _requestNavigationNotificationPermission();
+    if (!mounted) return;
     final position = _latestPosition;
     if (position != null) {
       _refreshVoiceGuidance(model, position);
@@ -1004,6 +1009,19 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     if (!mounted) return;
     await _applyNativeLocationTracking(model);
     await _updateLocationStream(model);
+  }
+
+  Future<void> _requestNavigationNotificationPermission() async {
+    if (defaultTargetPlatform != TargetPlatform.android) return;
+    try {
+      await _notificationPermissionChannel.invokeMethod<bool>('request');
+    } on PlatformException catch (error, stackTrace) {
+      log.w(
+        'Requesting navigation notification permission failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   Future<void> _refreshRouteAndResumeNavigation(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.1.7+45
+version: 3.1.7+46
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Die Benachrichtigung fehlte tatsächlich wegen einer nicht angeforderten Android-Berechtigung.
Behoben:
POST_NOTIFICATIONS im Android-Manifest ergänzt.
Beim ersten Navigationsstart fragt MunichWays jetzt nach der Benachrichtigungsfreigabe.
Der Vordergrunddienst bleibt auch bei Ablehnung funktionsfähig, seine Meldung ist dann aber nicht sichtbar.