### PR TITLE
164 finetuning bugfix 3113

### DIFF
--- a/lib/api/brouter_api.dart
+++ b/lib/api/brouter_api.dart
@@ -86,12 +86,22 @@ class BRouterApi implements RoutingProvider {
           (coordinate[0] as num).toDouble(),
         );
       }).toList(growable: false);
+      final destination = coordinates.last;
+      final destinationConnector = const Distance().as(
+                LengthUnit.Meter,
+                points.last,
+                destination,
+              ) >
+              1
+          ? [points.last, destination]
+          : <LatLng>[];
 
       return CycleRoute(
         points,
         _number(properties['track-length'], 'track-length'),
         _number(properties['total-time'], 'total-time'),
         supportsVoiceGuidance: false,
+        destinationConnector: destinationConnector,
       );
     } catch (error) {
       throw ApiException('Invalid BRouter response: $error');

--- a/lib/api/munichways/munichways_api.dart
+++ b/lib/api/munichways/munichways_api.dart
@@ -62,7 +62,9 @@ class MunichwaysApi {
     Duration? responseTimeout,
   }) async* {
     try {
-      final bundled = await getBundledRadlVorrangnetz();
+      final bundled = await (responseTimeout == null
+          ? getBundledRadlVorrangnetz()
+          : getBundledRadlVorrangnetz().timeout(responseTimeout));
       log.d('bundled RadlVorrang network loaded: ${bundled.length} polylines');
       yield bundled;
     } catch (e, st) {

--- a/lib/api/nominatim_api.dart
+++ b/lib/api/nominatim_api.dart
@@ -39,7 +39,8 @@ class NominatimApi {
   }) async {
     final queryParameters = {
       'q': query,
-      'format': 'jsonv2',
+      'format': 'geocodejson',
+      'addressdetails': '1',
       'limit': '15',
       if (localOnly) ...{
         'viewbox': _viewBox(center),
@@ -55,12 +56,7 @@ class NominatimApi {
       case 200:
         log.d(response.body);
         log.d(response.jsonBody());
-        List jsonList = response.jsonBody() as List;
-        var list = jsonList.map((json) {
-          return Place(json['display_name'],
-              LatLng(double.parse(json['lat']), double.parse(json['lon'])));
-        }).toList();
-        return list;
+        return _parsePlaces(response.jsonBody());
       default:
         throw ApiException("Error retrieving places: " + response.body);
     }
@@ -69,4 +65,122 @@ class NominatimApi {
   static String _viewBox(LatLng center) =>
       '${center.longitude - 0.35},${center.latitude + 0.25},'
       '${center.longitude + 0.35},${center.latitude - 0.25}';
+
+  static List<Place> _parsePlaces(dynamic json) {
+    if (json is Map<String, dynamic>) {
+      final features = json['features'];
+      if (features is! List) return const [];
+      return features
+          .whereType<Map<String, dynamic>>()
+          .map(_placeFromFeature)
+          .whereType<Place>()
+          .toList();
+    }
+
+    // Keep compatibility with proxies that still return JSONv2 despite the
+    // requested format.
+    if (json is List) {
+      return json.whereType<Map<String, dynamic>>().map((result) {
+        return Place(
+          _displayName(result),
+          LatLng(
+            double.parse(result['lat'].toString()),
+            double.parse(result['lon'].toString()),
+          ),
+        );
+      }).toList();
+    }
+    return const [];
+  }
+
+  static Place? _placeFromFeature(Map<String, dynamic> feature) {
+    final geometry = feature['geometry'];
+    final properties = feature['properties'];
+    if (geometry is! Map || properties is! Map) return null;
+    final coordinates = geometry['coordinates'];
+    final geocoding = properties['geocoding'];
+    if (coordinates is! List || coordinates.length < 2 || geocoding is! Map) {
+      return null;
+    }
+    final longitude = coordinates[0];
+    final latitude = coordinates[1];
+    if (longitude is! num || latitude is! num) return null;
+    final details = Map<String, dynamic>.from(geocoding);
+    return Place(
+      _geocodeJsonDisplayName(details),
+      LatLng(latitude.toDouble(), longitude.toDouble()),
+    );
+  }
+
+  static String _geocodeJsonDisplayName(Map<String, dynamic> details) {
+    String value(String key) => details[key]?.toString().trim() ?? '';
+    final streetPart = [value('street'), value('housenumber')]
+        .where((part) => part.isNotEmpty)
+        .join(' ');
+    final city = value('city').isNotEmpty ? value('city') : value('locality');
+    final cityPart =
+        [value('postcode'), city].where((part) => part.isNotEmpty).join(' ');
+    final adminName = _mostLocalAdministrativeName(details['admin']);
+    final compact = [value('name'), streetPart, adminName, cityPart]
+        .where((part) => part.isNotEmpty)
+        .toSet()
+        .join(', ');
+    return compact.isNotEmpty ? compact : value('label');
+  }
+
+  static String _mostLocalAdministrativeName(dynamic admin) {
+    if (admin is! Map) return '';
+    var highestLevel = -1;
+    var name = '';
+    for (final entry in admin.entries) {
+      final match =
+          RegExp(r'^(?:level)?(\d+)$').firstMatch(entry.key.toString());
+      final level = match == null ? null : int.tryParse(match.group(1)!);
+      final candidate = entry.value?.toString().trim() ?? '';
+      if (level != null && level > highestLevel && candidate.isNotEmpty) {
+        highestLevel = level;
+        name = candidate;
+      }
+    }
+    return name;
+  }
+
+  static String _displayName(Map<String, dynamic> result) {
+    final address = result['address'];
+    if (address is! Map) {
+      return result['display_name']?.toString().trim() ?? '';
+    }
+
+    String value(String key) => address[key]?.toString().trim() ?? '';
+    final street = value('road').isNotEmpty
+        ? value('road')
+        : value('pedestrian').isNotEmpty
+            ? value('pedestrian')
+            : value('place');
+    final houseNumber = value('house_number');
+    final streetPart =
+        [street, houseNumber].where((part) => part.isNotEmpty).join(' ');
+    final city = [
+      value('city'),
+      value('town'),
+      value('village'),
+      value('municipality'),
+    ].firstWhere((part) => part.isNotEmpty, orElse: () => '');
+    final cityPart =
+        [value('postcode'), city].where((part) => part.isNotEmpty).join(' ');
+    final resultName = result['name']?.toString().trim() ?? '';
+    final name = resultName.isNotEmpty
+        ? resultName
+        : value('amenity').isNotEmpty
+            ? value('amenity')
+            : value('shop');
+
+    final compact = [name, streetPart, cityPart]
+        .where((part) => part.isNotEmpty)
+        .toSet()
+        .join(', ');
+    return compact.isNotEmpty
+        ? compact
+        : result['display_name']?.toString().trim() ?? '';
+  }
 }

--- a/lib/api/radlnavi_api.dart
+++ b/lib/api/radlnavi_api.dart
@@ -68,9 +68,11 @@ class RadlNaviApi implements RoutingProvider {
         var distance = firstRoute['distance'] as num;
         var duration = firstRoute['duration'] as num;
         final maneuvers = <RouteManeuver>[];
+        final steps = <Map<String, dynamic>>[];
         for (final leg in firstRoute['legs'] as List? ?? const []) {
           for (final rawStep in leg['steps'] as List? ?? const []) {
             final step = rawStep as Map<String, dynamic>;
+            steps.add(step);
             final maneuver =
                 step['maneuver'] as Map<String, dynamic>? ?? const {};
             final location = maneuver['location'] as List?;
@@ -88,11 +90,33 @@ class RadlNaviApi implements RoutingProvider {
           }
         }
 
-        return CycleRoute(
+        final access = _splitDestinationAccess(
           points,
+          steps,
+          coordinates.last,
+        );
+        var spokenManeuvers = maneuvers;
+        if (access.walkingStart != null) {
+          final firstWalkingManeuver = maneuvers.indexWhere(
+            (maneuver) =>
+                const Distance().as(
+                  LengthUnit.Meter,
+                  maneuver.location,
+                  access.walkingStart!,
+                ) <=
+                1,
+          );
+          if (firstWalkingManeuver >= 0) {
+            spokenManeuvers = maneuvers.sublist(0, firstWalkingManeuver);
+          }
+        }
+
+        return CycleRoute(
+          access.route,
           distance.toDouble(),
           duration.toDouble(),
-          maneuvers: maneuvers,
+          maneuvers: spokenManeuvers,
+          destinationConnector: access.connector,
         );
       default:
         throw ApiException("Error retrieving route: " + response.body);
@@ -127,4 +151,71 @@ class RadlNaviApi implements RoutingProvider {
     }
     throw ApiException('Missing RadlNavi route geometry');
   }
+
+  _DestinationAccess _splitDestinationAccess(
+    List<LatLng> route,
+    List<Map<String, dynamic>> steps,
+    LatLng destination,
+  ) {
+    LatLng? walkingStart;
+    for (final step in steps.reversed) {
+      final maneuver = step['maneuver'] as Map<String, dynamic>? ?? const {};
+      if (maneuver['type'] == 'arrive') continue;
+      if (!_isUnriddenMode(step['mode'])) break;
+      final location = maneuver['location'] as List?;
+      if (location != null && location.length >= 2) {
+        walkingStart = LatLng(
+          (location[1] as num).toDouble(),
+          (location[0] as num).toDouble(),
+        );
+      }
+    }
+
+    var splitIndex = route.length - 1;
+    if (walkingStart != null && route.length > 1) {
+      var nearestDistance = double.infinity;
+      for (var index = route.length - 1; index >= 1; index--) {
+        final candidateDistance = const Distance().as(
+          LengthUnit.Meter,
+          route[index],
+          walkingStart,
+        );
+        if (candidateDistance < nearestDistance) {
+          nearestDistance = candidateDistance;
+          splitIndex = index;
+        }
+      }
+    }
+
+    final solidRoute = route.sublist(0, splitIndex + 1);
+    final connector =
+        walkingStart == null ? <LatLng>[] : route.sublist(splitIndex).toList();
+    final connectorStart = connector.isEmpty ? route.last : connector.last;
+    if (const Distance().as(
+          LengthUnit.Meter,
+          connectorStart,
+          destination,
+        ) >
+        1) {
+      if (connector.isEmpty) connector.add(route.last);
+      connector.add(destination);
+    }
+    return _DestinationAccess(solidRoute, connector, walkingStart);
+  }
+
+  static bool _isUnriddenMode(Object? mode) {
+    final value = mode?.toString().toLowerCase() ?? '';
+    return value == 'walking' ||
+        value == 'pushing bike' ||
+        value == 'pushing' ||
+        value == 'inaccessible';
+  }
+}
+
+class _DestinationAccess {
+  const _DestinationAccess(this.route, this.connector, this.walkingStart);
+
+  final List<LatLng> route;
+  final List<LatLng> connector;
+  final LatLng? walkingStart;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,14 @@ import 'package:provider/provider.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+  SystemChrome.setSystemUIOverlayStyle(
+    const SystemUiOverlayStyle(
+      statusBarColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.dark,
+      statusBarBrightness: Brightness.light,
+      systemStatusBarContrastEnforced: false,
+    ),
+  );
   final localeController = AppLocaleController();
   runApp(MunichWaysApp(localeController: localeController));
   localeController.load();

--- a/lib/model/route.dart
+++ b/lib/model/route.dart
@@ -6,6 +6,7 @@ class CycleRoute {
   double duration;
   List<RouteManeuver> maneuvers;
   bool supportsVoiceGuidance;
+  List<LatLng> destinationConnector;
 
   CycleRoute(
     this.points,
@@ -13,6 +14,7 @@ class CycleRoute {
     this.duration, {
     this.maneuvers = const [],
     this.supportsVoiceGuidance = true,
+    this.destinationConnector = const [],
   });
 }
 

--- a/lib/ui/map/map_overlay/map_navigation_header_bar.dart
+++ b/lib/ui/map/map_overlay/map_navigation_header_bar.dart
@@ -119,9 +119,7 @@ class MapNavigationHeaderBar extends StatelessWidget {
 
     final refreshEnabled = route.state != MapRouteState.LOADING;
     final refreshLabel = refreshEnabled
-        ? (context.l10n.isEnglish
-            ? 'Recalculate route'
-            : 'Route neu berechnen')
+        ? (context.l10n.isEnglish ? 'Recalculate route' : 'Route neu berechnen')
         : (context.l10n.isEnglish
             ? 'Calculating route'
             : 'Route wird berechnet');
@@ -155,7 +153,8 @@ class MapNavigationHeaderBar extends StatelessWidget {
               ),
       ),
     );
-    final editLabel = context.l10n.isEnglish ? 'Edit route' : 'Route bearbeiten';
+    final editLabel =
+        context.l10n.isEnglish ? 'Edit route' : 'Route bearbeiten';
     final editAction = Semantics(
       container: true,
       button: true,

--- a/lib/ui/map/map_overlay/map_navigation_header_bar.dart
+++ b/lib/ui/map/map_overlay/map_navigation_header_bar.dart
@@ -117,33 +117,57 @@ class MapNavigationHeaderBar extends StatelessWidget {
         break;
     }
 
-    final refreshAction = IconButton.filled(
-      style: IconButton.styleFrom(
-        backgroundColor: Colors.white,
-        foregroundColor: AppColors.mapRouteColor,
-        disabledBackgroundColor: Colors.white54,
-        disabledForegroundColor: AppColors.mapRouteColor,
-        minimumSize: const Size(44, 44),
-      ),
-      padding: const EdgeInsets.all(10),
-      tooltip: route.state == MapRouteState.LOADING
-          ? (context.l10n.isEnglish
-              ? 'Calculating route'
-              : 'Route wird berechnet')
-          : (context.l10n.isEnglish
-              ? 'Recalculate route'
-              : 'Route neu berechnen'),
-      onPressed: route.state == MapRouteState.LOADING ? null : onRefreshRoute,
-      icon: route.state == MapRouteState.LOADING
-          ? const SizedBox(
-              width: 22,
-              height: 22,
-              child: CircularProgressIndicator(
-                color: AppColors.mapRouteColor,
-                strokeWidth: 2.5,
+    final refreshEnabled = route.state != MapRouteState.LOADING;
+    final refreshLabel = refreshEnabled
+        ? (context.l10n.isEnglish
+            ? 'Recalculate route'
+            : 'Route neu berechnen')
+        : (context.l10n.isEnglish
+            ? 'Calculating route'
+            : 'Route wird berechnet');
+    final refreshAction = Semantics(
+      container: true,
+      button: true,
+      enabled: refreshEnabled,
+      label: refreshLabel,
+      onTap: refreshEnabled ? onRefreshRoute : null,
+      excludeSemantics: true,
+      child: IconButton.filled(
+        style: IconButton.styleFrom(
+          backgroundColor: Colors.white,
+          foregroundColor: AppColors.mapRouteColor,
+          disabledBackgroundColor: Colors.white54,
+          disabledForegroundColor: AppColors.mapRouteColor,
+          minimumSize: const Size(44, 44),
+        ),
+        padding: const EdgeInsets.all(10),
+        tooltip: refreshLabel,
+        onPressed: refreshEnabled ? onRefreshRoute : null,
+        icon: refreshEnabled
+            ? const Icon(Icons.refresh, size: 26)
+            : const SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(
+                  color: AppColors.mapRouteColor,
+                  strokeWidth: 2.5,
+                ),
               ),
-            )
-          : const Icon(Icons.refresh, size: 26),
+      ),
+    );
+    final editLabel = context.l10n.isEnglish ? 'Edit route' : 'Route bearbeiten';
+    final editAction = Semantics(
+      container: true,
+      button: true,
+      label: editLabel,
+      onTap: onEditRoute,
+      excludeSemantics: true,
+      child: IconButton(
+        color: Colors.white,
+        tooltip: editLabel,
+        onPressed: onEditRoute,
+        icon: const Icon(Icons.edit_location_alt),
+      ),
     );
     final closeLabel = context.l10n.tr('Route beenden');
     final closeAction = Semantics(
@@ -210,14 +234,7 @@ class MapNavigationHeaderBar extends StatelessWidget {
               children: [
                 closeAction,
                 const Spacer(),
-                IconButton(
-                  color: Colors.white,
-                  tooltip: context.l10n.isEnglish
-                      ? 'Edit route'
-                      : 'Route bearbeiten',
-                  onPressed: onEditRoute,
-                  icon: const Icon(Icons.edit_location_alt),
-                ),
+                editAction,
                 if (route.state == MapRouteState.SHOWN &&
                     route.route != null &&
                     model.navigationStarted &&

--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -66,6 +66,8 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
   /// depends on network layer ids being present.
   static const _kRouteSourceId = 'munichways_route';
   static const _kRouteLayerId = 'munichways_route_line';
+  static const _kRouteConnectorSourceId = 'munichways_route_connector';
+  static const _kRouteConnectorLayerId = 'munichways_route_connector_line';
 
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey();
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey = GlobalKey();
@@ -383,8 +385,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
           }
           _scheduleOverlaySync(model);
 
-          if (model.initialRatingsLoadFailed &&
-              !_initialRatingsRetryOffered) {
+          if (model.initialRatingsLoadFailed && !_initialRatingsRetryOffered) {
             _initialRatingsRetryOffered = true;
             WidgetsBinding.instance.addPostFrameCallback((_) {
               if (mounted) _offerInitialRatingsReload(model);
@@ -1549,6 +1550,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
   int _routeFingerprint(MapScreenViewModel model) {
     final r = model.route.route;
     final pts = r?.points;
+    final connector = r?.destinationConnector;
     double? lat1, lng1, lat2, lng2;
     if (pts != null && pts.isNotEmpty) {
       lat1 = pts.first.latitude;
@@ -1563,6 +1565,11 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
       lng1,
       lat2,
       lng2,
+      connector?.length,
+      connector?.firstOrNull?.latitude,
+      connector?.firstOrNull?.longitude,
+      connector?.lastOrNull?.latitude,
+      connector?.lastOrNull?.longitude,
       model.destination?.latLng.latitude,
       model.destination?.latLng.longitude,
       model.routeStart?.latLng.latitude,
@@ -1630,6 +1637,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     _routePlanCircles.clear();
 
     if (model.route.state == MapRouteState.SHOWN && model.route.route != null) {
+      final route = model.route.route!;
       await controller.setGeoJsonSource(_kRouteSourceId, {
         'type': 'FeatureCollection',
         'features': [
@@ -1637,15 +1645,34 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
             'type': 'Feature',
             'geometry': {
               'type': 'LineString',
-              'coordinates': model.route.route!.points
-                  .map((p) => [p.longitude, p.latitude])
-                  .toList(),
+              'coordinates':
+                  route.points.map((p) => [p.longitude, p.latitude]).toList(),
             },
           },
         ],
       });
+      await controller.setGeoJsonSource(_kRouteConnectorSourceId, {
+        'type': 'FeatureCollection',
+        'features': route.destinationConnector.length < 2
+            ? <dynamic>[]
+            : [
+                {
+                  'type': 'Feature',
+                  'geometry': {
+                    'type': 'LineString',
+                    'coordinates': route.destinationConnector
+                        .map((p) => [p.longitude, p.latitude])
+                        .toList(),
+                  },
+                },
+              ],
+      });
     } else {
       await controller.setGeoJsonSource(_kRouteSourceId, {
+        'type': 'FeatureCollection',
+        'features': <dynamic>[],
+      });
+      await controller.setGeoJsonSource(_kRouteConnectorSourceId, {
         'type': 'FeatureCollection',
         'features': <dynamic>[],
       });
@@ -1715,7 +1742,9 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
     if (!_routeGeoJsonReady) return;
     try {
       await controller.removeLayer(_kRouteLayerId);
+      await controller.removeLayer(_kRouteConnectorLayerId);
       await controller.removeSource(_kRouteSourceId);
+      await controller.removeSource(_kRouteConnectorSourceId);
     } catch (_) {
       // Style may have already dropped layers.
     }
@@ -1728,6 +1757,10 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
       'type': 'FeatureCollection',
       'features': <dynamic>[],
     });
+    await controller.addGeoJsonSource(_kRouteConnectorSourceId, {
+      'type': 'FeatureCollection',
+      'features': <dynamic>[],
+    });
     await controller.addLineLayer(
       _kRouteSourceId,
       _kRouteLayerId,
@@ -1736,6 +1769,19 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
         lineWidth: MapOverlayLineStyle.routeLineWidthByZoom,
         lineCap: 'round',
         lineJoin: 'round',
+      ),
+      belowLayerId: kOpenFreeMapBasemapOverlayBelowLayerId,
+      enableInteraction: false,
+    );
+    await controller.addLineLayer(
+      _kRouteConnectorSourceId,
+      _kRouteConnectorLayerId,
+      LineLayerProperties(
+        lineColor: _hexColor(AppColors.mapRouteColor),
+        lineWidth: MapOverlayLineStyle.routeLineWidthByZoom,
+        lineCap: 'round',
+        lineJoin: 'round',
+        lineDasharray: const [1.5, 1.5],
       ),
       belowLayerId: kOpenFreeMapBasemapOverlayBelowLayerId,
       enableInteraction: false,

--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -609,6 +609,14 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
                         ),
                       ),
                     ),
+                  if (Platform.isAndroid)
+                    Positioned(
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      height: MediaQuery.paddingOf(context).top,
+                      child: const ColoredBox(color: Colors.white),
+                    ),
                   SafeArea(
                     child: Stack(
                       clipBehavior: Clip.none,
@@ -1017,10 +1025,25 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
   Future<void> _zoomOutAfterMissingDirections() async {
     final controller = _mapController;
     if (!mounted || controller == null) return;
-    final currentZoom = _safeZoom(controller.cameraPosition?.zoom);
-    await controller.animateCamera(
-      CameraUpdate.zoomTo((currentZoom - 2).clamp(3.0, 22.0)),
-    );
+    try {
+      // `controller.cameraPosition` can remain at the value from before a
+      // programmatic camera animation. Reading the native position prevents
+      // subsequent warnings from repeatedly targeting the already active zoom.
+      final position = await controller.queryCameraPosition();
+      if (!mounted || controller != _mapController) return;
+      final currentZoom = _safeZoom(
+        position?.zoom ?? controller.cameraPosition?.zoom,
+      );
+      await controller.animateCamera(
+        CameraUpdate.zoomTo((currentZoom - 2).clamp(3.0, 22.0)),
+      );
+    } catch (error, stackTrace) {
+      log.d(
+        'Zooming out after missing directions skipped while map is updating',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   Future<void> _startNavigation(MapScreenViewModel model) async {
@@ -1295,8 +1318,13 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
 
   Future<void> _refreshLocationOnResume(MapScreenViewModel model) async {
     if (model.locationState == LocationState.NOT_AVAILABLE) return;
-    await model.refreshCurrentLocationFix();
+    final locationAvailable = await model.refreshCurrentLocationFix();
     if (!mounted) return;
+    if (!locationAvailable) {
+      await _applyNativeLocationTracking(model);
+      await _updateLocationStream(model);
+      return;
+    }
     await _applyNativeLocationTracking(model);
     await _updateLocationStream(model);
   }

--- a/lib/ui/map/map_screen.dart
+++ b/lib/ui/map/map_screen.dart
@@ -127,6 +127,7 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
   bool _storeScreenshotNetworkSynced = false;
   bool _storeScreenshotIdleCameraDone = false;
   bool _storeScreenshotIdleCameraScheduled = false;
+  bool _initialRatingsRetryOffered = false;
   bool _storeScreenshotRouteVisualReady = false;
 
   /// Whether to embed [MapLibreMap]; false briefly on iOS only (see [initState]).
@@ -381,6 +382,14 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
             });
           }
           _scheduleOverlaySync(model);
+
+          if (model.initialRatingsLoadFailed &&
+              !_initialRatingsRetryOffered) {
+            _initialRatingsRetryOffered = true;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) _offerInitialRatingsReload(model);
+            });
+          }
 
           if (kStoreScreenshots &&
               _storeScreenshotNetworkSynced &&
@@ -1044,6 +1053,47 @@ class _MapScreenState extends State<MapScreen> with WidgetsBindingObserver {
         stackTrace: stackTrace,
       );
     }
+  }
+
+  void _offerInitialRatingsReload(MapScreenViewModel model) {
+    final messenger = scaffoldMessengerKey.currentState;
+    if (messenger == null) return;
+    final strings = context.l10n;
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          duration: const Duration(seconds: 12),
+          content: Text(
+            strings.isEnglish
+                ? 'Ratings could not be loaded.'
+                : 'Bewertungen konnten nicht geladen werden.',
+          ),
+          action: SnackBarAction(
+            label: strings.reloadNetwork,
+            onPressed: () {
+              unawaited(_reloadRadnetzAfterInitialFailure(model));
+            },
+          ),
+        ),
+      );
+  }
+
+  Future<void> _reloadRadnetzAfterInitialFailure(
+    MapScreenViewModel model,
+  ) async {
+    final updated = await model.reloadRadnetz();
+    if (!mounted) return;
+    final strings = context.l10n;
+    scaffoldMessengerKey.currentState
+      ?..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            updated ? strings.mapUpdated : strings.mapUpdateFailed,
+          ),
+        ),
+      );
   }
 
   Future<void> _startNavigation(MapScreenViewModel model) async {

--- a/lib/ui/map/map_screen_model.dart
+++ b/lib/ui/map/map_screen_model.dart
@@ -45,6 +45,7 @@ class MapScreenViewModel extends ChangeNotifier {
   bool _firstLoad = true;
   bool _initialLoadStarted = false;
   bool get initialLoadComplete => !_firstLoad;
+  bool initialRatingsLoadFailed = false;
 
   /// Set true after [primeLocationForStoreScreenshots] finishes (success or hard failure).
   bool storeScreenshotLocationPrimeComplete = false;
@@ -506,9 +507,11 @@ class MapScreenViewModel extends ChangeNotifier {
     Duration requestTimeout = _ratingsRequestTimeout,
   }) async {
     final startedAt = DateTime.now();
+    final isInitialLoad = _firstLoad;
     loading = true;
     notifyListeners();
     var receivedData = false;
+    var refreshFailed = false;
     var detailsLoadStarted = false;
 
     try {
@@ -538,6 +541,7 @@ class MapScreenViewModel extends ChangeNotifier {
       }
       return receivedData;
     } catch (e) {
+      refreshFailed = true;
       if (!receivedData) {
         _displayErrorMsg(
           'Bewertungen konnten nicht geladen werden. '
@@ -547,7 +551,7 @@ class MapScreenViewModel extends ChangeNotifier {
       if (e is! TimeoutException) {
         log.e("Error loading Netze", error: e);
       }
-      return receivedData;
+      return false;
     } finally {
       final remaining =
           minimumLoadingDuration - DateTime.now().difference(startedAt);
@@ -556,6 +560,9 @@ class MapScreenViewModel extends ChangeNotifier {
       }
       if (_firstLoad) {
         _firstLoad = false;
+      }
+      if (isInitialLoad && refreshFailed) {
+        initialRatingsLoadFailed = true;
       }
       loading = false;
       log.d(
@@ -569,6 +576,7 @@ class MapScreenViewModel extends ChangeNotifier {
   /// Clears the Radnetz GeoJSON cache, then downloads and parses it again so the map
   /// overlay can update without leaving the screen.
   Future<bool> reloadRadnetz() async {
+    initialRatingsLoadFailed = false;
     loading = true;
     notifyListeners();
     await _munichwaysApi.removeRatingsCache();

--- a/lib/ui/map/map_screen_model.dart
+++ b/lib/ui/map/map_screen_model.dart
@@ -295,14 +295,21 @@ class MapScreenViewModel extends ChangeNotifier {
   }
 
   /// Requests a fresh GPS fix so Android's cached last-known location is updated.
-  /// Failures are logged and ignored so callers can continue either way.
-  Future<void> refreshCurrentLocationFix() async {
+  /// Returns false without requesting a fix when system location is disabled.
+  Future<bool> refreshCurrentLocationFix() async {
+    if (!await Geolocator.isLocationServiceEnabled()) {
+      locationState = LocationState.NOT_AVAILABLE;
+      notifyListeners();
+      return false;
+    }
     try {
       await Geolocator.getCurrentPosition(
         locationSettings: _refreshLocationSettings,
       );
+      return true;
     } catch (e, st) {
       log.d('refreshCurrentLocationFix failed', error: e, stackTrace: st);
+      return false;
     }
   }
 
@@ -403,15 +410,14 @@ class MapScreenViewModel extends ChangeNotifier {
   Future<void> onPressLocationBtn({bool permissionCheck = true}) async {
     log.d("onPressLocationBtn");
     bool isLocationServiceEnabled = await Geolocator.isLocationServiceEnabled();
-    if (permissionCheck && !permissionCheck) {
-      log.d("ignore disable location service after return from settings");
-      return;
-    }
-
     if (!isLocationServiceEnabled) {
       locationState = LocationState.NOT_AVAILABLE;
       notifyListeners();
-      _showEnableLocationServiceDialogController.add("");
+      if (permissionCheck) {
+        _showEnableLocationServiceDialogController.add("");
+      } else {
+        log.d("location service disabled; continue without location");
+      }
       return;
     }
 

--- a/lib/ui/map/voice_guidance.dart
+++ b/lib/ui/map/voice_guidance.dart
@@ -40,8 +40,11 @@ class VoiceGuidance {
   final Set<int> _spokenArrivals = {};
   int _offRouteUpdates = 0;
   bool _offRouteWarningSpoken = false;
-  List<RouteManeuver> _arrivals = const [];
+  List<_GuidanceManeuver> _arrivals = const [];
   List<String?> _intermediateDestinationNames = const [];
+  double _routeProgress = 0;
+  bool _overlappingRouteUnsupported = false;
+  bool _overlappingRouteWarningSpoken = false;
 
   void setRoute(
     CycleRoute? route, {
@@ -56,26 +59,39 @@ class VoiceGuidance {
     _offRouteUpdates = 0;
     _offRouteWarningSpoken = false;
     _arrivals = const [];
+    _routeProgress = 0;
+    _overlappingRouteUnsupported = false;
+    _overlappingRouteWarningSpoken = false;
     _intermediateDestinationNames =
         List<String?>.of(intermediateDestinationNames);
     if (route == null || route.points.length < 2) {
       _maneuvers = const [];
       return;
     }
-    final routedManeuvers = route.maneuvers
-        .where(_isRelevant)
-        .map((maneuver) => _GuidanceManeuver(
-              maneuver,
-              _projectOntoRoute(route.points, maneuver.location)
-                  .distanceAlongRoute,
-            ))
+    _overlappingRouteUnsupported = intermediateDestinationNames.isNotEmpty &&
+        _hasRepeatedRouteSegment(route.points);
+    final projectedManeuvers = <_GuidanceManeuver>[];
+    var previousManeuverDistance = 0.0;
+    for (final maneuver in route.maneuvers) {
+      final projection = _projectOntoRoute(
+        route.points,
+        maneuver.location,
+        minimumDistanceAlongRoute: previousManeuverDistance,
+      );
+      previousManeuverDistance = projection.distanceAlongRoute;
+      projectedManeuvers.add(
+        _GuidanceManeuver(maneuver, projection.distanceAlongRoute),
+      );
+    }
+    final routedManeuvers = projectedManeuvers
+        .where((maneuver) => _isRelevant(maneuver.maneuver))
         .toList();
     _maneuvers = [
       ...routedManeuvers,
       ..._geometryTurns(route, routedManeuvers),
     ]..sort((a, b) => a.routeDistance.compareTo(b.routeDistance));
-    _arrivals = route.maneuvers
-        .where((maneuver) => maneuver.type == 'arrive')
+    _arrivals = projectedManeuvers
+        .where((maneuver) => maneuver.maneuver.type == 'arrive')
         .toList(growable: false);
   }
 
@@ -88,20 +104,35 @@ class VoiceGuidance {
   }) {
     final route = _route;
     if (route == null) return null;
+    if (_overlappingRouteUnsupported) {
+      return VoiceGuidanceDisplay(
+        text: english
+            ? 'No turn directions for overlapping route sections'
+            : 'Keine Abbiegehinweise bei überlappendem Hin- und Rückweg',
+        type: 'notification',
+      );
+    }
 
-    final projection = _projectOntoRoute(route.points, position);
+    final projection = _projectOntoRoute(
+      route.points,
+      position,
+      minimumDistanceAlongRoute: _routeProgress,
+    );
     if (projection.distanceFromRoute > maximumRouteDistanceMeters) {
       return null;
     }
 
     final arrivalIndex = _arrivalIndexAt(position);
     if (arrivalIndex != null) {
+      _routeProgress =
+          max(_routeProgress, _arrivals[arrivalIndex].routeDistance);
       return VoiceGuidanceDisplay(
         text: _arrivalDisplay(arrivalIndex, english),
         type: 'arrive',
       );
     }
 
+    _routeProgress = max(_routeProgress, projection.distanceAlongRoute);
     final travelled = _predictedDistanceAlongRoute(
       projection.distanceAlongRoute,
       speedMetersPerSecond,
@@ -130,8 +161,21 @@ class VoiceGuidance {
   }) {
     final route = _route;
     if (route == null) return null;
+    if (_overlappingRouteUnsupported) {
+      if (_overlappingRouteWarningSpoken) return null;
+      _overlappingRouteWarningSpoken = true;
+      return english
+          ? 'Outbound and return routes overlap. No turn directions. '
+              'Please follow the route on the map.'
+          : 'Hin- und Rückweg überlappen. Keine Abbiegehinweise. '
+              'Bitte der Route auf der Karte folgen.';
+    }
 
-    final projection = _projectOntoRoute(route.points, position);
+    final projection = _projectOntoRoute(
+      route.points,
+      position,
+      minimumDistanceAlongRoute: _routeProgress,
+    );
     if (projection.distanceFromRoute > maximumRouteDistanceMeters) {
       _offRouteUpdates++;
       if (!_offRouteWarningSpoken &&
@@ -148,10 +192,13 @@ class VoiceGuidance {
 
     final arrivalIndex = _arrivalIndexAt(position);
     if (arrivalIndex != null && _spokenArrivals.add(arrivalIndex)) {
+      _routeProgress =
+          max(_routeProgress, _arrivals[arrivalIndex].routeDistance);
       return _arrivalAnnouncement(arrivalIndex, english);
     }
 
     if (_index >= _maneuvers.length) return null;
+    _routeProgress = max(_routeProgress, projection.distanceAlongRoute);
     final travelled = _predictedDistanceAlongRoute(
       projection.distanceAlongRoute,
       speedMetersPerSecond,
@@ -187,14 +234,19 @@ class VoiceGuidance {
 
   int? _arrivalIndexAt(LatLng position) {
     for (var index = 0; index < _arrivals.length; index++) {
+      if (_spokenArrivals.contains(index)) continue;
       if (const Distance().as(
             LengthUnit.Meter,
             position,
-            _arrivals[index].location,
+            _arrivals[index].maneuver.location,
           ) <=
           arrivalDistanceMeters) {
         return index;
       }
+      // Intermediate destinations must be reached in their planned order.
+      // Otherwise a destination near an outbound section could be mistaken
+      // for reached before a preceding stop on an overlapping return section.
+      return null;
     }
     return null;
   }
@@ -295,6 +347,22 @@ class VoiceGuidance {
       maneuver.type != 'notification' &&
       !(maneuver.type == 'new name' &&
           (maneuver.modifier == null || maneuver.modifier == 'straight'));
+
+  static bool _hasRepeatedRouteSegment(List<LatLng> points) {
+    final segments = <String>{};
+    for (var index = 0; index < points.length - 1; index++) {
+      final start = _routePointKey(points[index]);
+      final end = _routePointKey(points[index + 1]);
+      if (start == end) continue;
+      final key = start.compareTo(end) < 0 ? '$start|$end' : '$end|$start';
+      if (!segments.add(key)) return true;
+    }
+    return false;
+  }
+
+  static String _routePointKey(LatLng point) =>
+      '${(point.latitude * 100000).round()}:'
+      '${(point.longitude * 100000).round()}';
 
   /// Adds clear corners that routing services sometimes omit when the route
   /// follows the same named foot/cycle way through a junction.
@@ -467,8 +535,9 @@ class VoiceGuidance {
 
   static _RouteProjection _projectOntoRoute(
     List<LatLng> route,
-    LatLng point,
-  ) {
+    LatLng point, {
+    double minimumDistanceAlongRoute = 0,
+  }) {
     var cumulative = 0.0;
     var bestDistanceSquared = double.infinity;
     var bestAlong = 0.0;
@@ -493,9 +562,11 @@ class VoiceGuidance {
       final py = ay + dy * t;
       final distanceSquared = px * px + py * py;
       final segmentLength = sqrt(lengthSquared);
-      if (distanceSquared < bestDistanceSquared) {
+      final distanceAlong = cumulative + segmentLength * t;
+      if (distanceAlong + 1 >= minimumDistanceAlongRoute &&
+          distanceSquared < bestDistanceSquared) {
         bestDistanceSquared = distanceSquared;
-        bestAlong = cumulative + segmentLength * t;
+        bestAlong = distanceAlong;
       }
       cumulative += segmentLength;
     }

--- a/lib/ui/place_search/place_search_body.dart
+++ b/lib/ui/place_search/place_search_body.dart
@@ -183,37 +183,32 @@ class PlaceSearchBody extends StatelessWidget {
       ),
       for (final favorite in model.favoritePlaces) ...[
         const Divider(height: 1),
-        ListTile(
-          dense: true,
-          leading: Icon(
-            Icons.star,
-            color: Theme.of(context).colorScheme.primary,
-          ),
-          title: Text(
-            favorite.displayName!,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  fontWeight: FontWeight.w500,
-                ),
-          ),
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              IconButton(
-                tooltip: context.l10n.isEnglish ? 'Rename' : 'Umbenennen',
-                onPressed: () => _renameFavorite(context, model, favorite),
-                icon: const Icon(Icons.edit_outlined),
-              ),
-              IconButton(
-                tooltip: context.l10n.isEnglish ? 'Remove' : 'Entfernen',
-                onPressed: () => model.toggleFavorite(favorite),
-                icon: const Icon(Icons.delete_outline),
-              ),
-            ],
-          ),
-          onTap: () {
-            model.addToRecentSearches(favorite);
-            Navigator.pop(context, favorite);
-          },
+        _savedPlaceTile(
+          context,
+          favorite,
+          actions: [
+            _routeButton(context, model, favorite),
+            IconButton(
+              tooltip: context.l10n.isEnglish ? 'Rename' : 'Umbenennen',
+              onPressed: () => _renameFavorite(context, model, favorite),
+              icon: const Icon(Icons.edit_outlined),
+            ),
+            IconButton(
+              tooltip: context.l10n.isEnglish
+                  ? 'Remove favorite'
+                  : 'Favorit entfernen',
+              onPressed: () => model.toggleFavorite(favorite),
+              icon: const Icon(Icons.star),
+            ),
+            IconButton(
+              tooltip: context.l10n.isEnglish
+                  ? 'Delete permanently'
+                  : 'Endgültig löschen',
+              onPressed: () => model.deleteSavedPlace(favorite),
+              icon: const Icon(Icons.delete_outline),
+            ),
+          ],
+          onRoute: () => _selectPlace(context, model, favorite),
         ),
       ],
     ];
@@ -273,45 +268,57 @@ class PlaceSearchBody extends StatelessWidget {
       ),
       for (final recentSearch in model.recentSearches) ...[
         const Divider(height: 1),
-        ListTile(
-          dense: true,
-          leading: const Icon(Icons.history, color: Colors.black45),
-          title: Text(
-            recentSearch.displayName!,
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-          trailing: IconButton(
-            tooltip: model.isFavorite(recentSearch)
-                ? (context.l10n.isEnglish
-                    ? 'Remove favorite'
-                    : 'Favorit entfernen')
-                : (context.l10n.isEnglish
-                    ? 'Add favorite'
-                    : 'Als Favorit speichern'),
-            onPressed: () async {
-              final isFavorite = model.isFavorite(recentSearch);
-              if (!isFavorite && model.favoritePlaces.length >= 3) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                      context.l10n.isEnglish
-                          ? 'A maximum of three favorites is possible.'
-                          : 'Es sind maximal drei Favoriten möglich.',
-                    ),
-                  ),
-                );
-                return;
-              }
-              await model.toggleFavorite(recentSearch);
-            },
-            icon: Icon(
-              model.isFavorite(recentSearch) ? Icons.star : Icons.star_border,
+        _savedPlaceTile(
+          context,
+          recentSearch,
+          actions: [
+            _routeButton(context, model, recentSearch),
+            IconButton(
+              tooltip: context.l10n.isEnglish ? 'Rename' : 'Umbenennen',
+              onPressed: () => _renameRecentSearch(
+                context,
+                model,
+                recentSearch,
+              ),
+              icon: const Icon(Icons.edit_outlined),
             ),
-          ),
-          onTap: () {
-            model.addToRecentSearches(recentSearch);
-            Navigator.pop(context, recentSearch);
-          },
+            IconButton(
+              tooltip: model.isFavorite(recentSearch)
+                  ? (context.l10n.isEnglish
+                      ? 'Remove favorite'
+                      : 'Favorit entfernen')
+                  : (context.l10n.isEnglish
+                      ? 'Add favorite'
+                      : 'Als Favorit speichern'),
+              onPressed: () async {
+                final isFavorite = model.isFavorite(recentSearch);
+                if (!isFavorite && model.favoritePlaces.length >= 3) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        context.l10n.isEnglish
+                            ? 'A maximum of three favorites is possible.'
+                            : 'Es sind maximal drei Favoriten möglich.',
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                await model.toggleFavorite(recentSearch);
+              },
+              icon: Icon(
+                model.isFavorite(recentSearch) ? Icons.star : Icons.star_border,
+              ),
+            ),
+            IconButton(
+              tooltip: context.l10n.isEnglish
+                  ? 'Delete permanently'
+                  : 'Endgültig löschen',
+              onPressed: () => model.deleteSavedPlace(recentSearch),
+              icon: const Icon(Icons.delete_outline),
+            ),
+          ],
+          onRoute: () => _selectPlace(context, model, recentSearch),
         ),
       ],
       Align(
@@ -323,5 +330,88 @@ class PlaceSearchBody extends StatelessWidget {
         ),
       ),
     ];
+  }
+
+  Future<void> _renameRecentSearch(
+    BuildContext context,
+    PlaceSearchScreenViewModel model,
+    Place recentSearch,
+  ) async {
+    var name = recentSearch.displayName ?? '';
+    final updatedName = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(
+          context.l10n.isEnglish ? 'Rename destination' : 'Ziel umbenennen',
+        ),
+        content: TextFormField(
+          initialValue: name,
+          autofocus: true,
+          onChanged: (value) => name = value,
+          onFieldSubmitted: (value) => Navigator.pop(dialogContext, value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: Text(context.l10n.tr('Abbrechen')),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, name),
+            child: Text(context.l10n.isEnglish ? 'Save' : 'Speichern'),
+          ),
+        ],
+      ),
+    );
+    final trimmedName = updatedName?.trim();
+    if (trimmedName == null || trimmedName.isEmpty) return;
+    await model.renameRecentSearch(recentSearch, trimmedName);
+  }
+
+  Widget _savedPlaceTile(
+    BuildContext context,
+    Place place, {
+    required List<Widget> actions,
+    required VoidCallback onRoute,
+  }) {
+    return InkWell(
+      onTap: onRoute,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 2, 4, 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(mainAxisAlignment: MainAxisAlignment.end, children: actions),
+            Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: Text(
+                place.displayName!,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _routeButton(
+    BuildContext context,
+    PlaceSearchScreenViewModel model,
+    Place place,
+  ) {
+    return IconButton(
+      tooltip: context.l10n.isEnglish ? 'Calculate route' : 'Route berechnen',
+      onPressed: () => _selectPlace(context, model, place),
+      icon: const Icon(Icons.directions_bike_outlined),
+    );
+  }
+
+  void _selectPlace(
+    BuildContext context,
+    PlaceSearchScreenViewModel model,
+    Place place,
+  ) {
+    model.addToRecentSearches(place);
+    Navigator.pop(context, place);
   }
 }

--- a/lib/ui/place_search/place_search_screen_model.dart
+++ b/lib/ui/place_search/place_search_screen_model.dart
@@ -240,9 +240,50 @@ class PlaceSearchScreenViewModel extends ChangeNotifier {
     await favoritesRepo.store(favoritePlaces);
   }
 
+  Future<void> renameRecentSearch(Place place, String name) async {
+    final recentIndex = recentSearches.indexWhere(
+      (recent) =>
+          recent.latLng.latitude == place.latLng.latitude &&
+          recent.latLng.longitude == place.latLng.longitude,
+    );
+    if (recentIndex < 0) return;
+    final renamed = Place(name, place.latLng);
+    recentSearches[recentIndex] = renamed;
+
+    final favoriteIndex = favoritePlaces.indexWhere(
+      (favorite) =>
+          favorite.latLng.latitude == place.latLng.latitude &&
+          favorite.latLng.longitude == place.latLng.longitude,
+    );
+    if (favoriteIndex >= 0) {
+      favoritePlaces[favoriteIndex] = renamed;
+      await favoritesRepo.store(favoritePlaces);
+    }
+    _notifyListeners();
+    await recentSearchesRepo.store(recentSearches);
+  }
+
   void clearAllRecentSearches() {
     recentSearches.clear();
     recentSearchesRepo.store(recentSearches);
     _notifyListeners();
+  }
+
+  Future<void> deleteSavedPlace(Place place) async {
+    recentSearches.removeWhere(
+      (recent) =>
+          recent.latLng.latitude == place.latLng.latitude &&
+          recent.latLng.longitude == place.latLng.longitude,
+    );
+    favoritePlaces.removeWhere(
+      (favorite) =>
+          favorite.latLng.latitude == place.latLng.latitude &&
+          favorite.latLng.longitude == place.latLng.longitude,
+    );
+    _notifyListeners();
+    await Future.wait([
+      recentSearchesRepo.store(recentSearches),
+      favoritesRepo.store(favoritePlaces),
+    ]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.1.12+51
+version: 3.1.13+52
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/api/nominatim_api_test.dart
+++ b/test/api/nominatim_api_test.dart
@@ -12,7 +12,8 @@ void main() {
       //Then
       expect(req.url.path, "/search");
       expect(req.url.queryParameters['q'], 'Marienplatz');
-      expect(req.url.queryParameters['format'], 'jsonv2');
+      expect(req.url.queryParameters['format'], 'geocodejson');
+      expect(req.url.queryParameters['addressdetails'], '1');
       expect(
         req.url.queryParameters['viewbox'],
         '11.226124,48.387154,11.926124,47.887154',
@@ -60,5 +61,23 @@ void main() {
 
     expect(requestCount, 2);
     expect(places.single.displayName, 'Alexanderplatz, Berlin');
+  });
+
+  test('uses the highest admin level as the single district name', () async {
+    final api = NominatimApi(client: MockClient((request) async {
+      return Response(
+        '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[11.557,48.128]},"properties":{"geocoding":{"name":"Doctor Drooly","housenumber":"7","street":"Häberlstraße","postcode":"80337","city":"München","admin":{"level6":"München","level9":"Ludwigsvorstadt-Isarvorstadt","level10":"Ludwigsvorstadt"},"label":"Doctor Drooly, Häberlstraße 7, München"}}}]}',
+        200,
+        headers: {'content-type': 'application/json; charset=UTF-8'},
+      );
+    }));
+
+    final places = await api.search('Drooly');
+
+    expect(
+      places.single.displayName,
+      'Doctor Drooly, Häberlstraße 7, Ludwigsvorstadt, 80337 München',
+    );
+    expect(places.single.latLng, const LatLng(48.128, 11.557));
   });
 }

--- a/test/api/radlnavi_api_test.dart
+++ b/test/api/radlnavi_api_test.dart
@@ -60,6 +60,33 @@ void main() {
     expect(route.maneuvers.last.type, 'arrive');
   });
 
+  test('separates a final walking section from the cycling route', () async {
+    final api = RadlNaviApi(client: MockClient((_) async {
+      return Response(
+        '{"code":"Ok","routes":[{"geometry":{"type":"LineString","coordinates":[[11.5700,48.1400],[11.5710,48.1410],[11.5715,48.1415]]},"legs":[{"steps":[{"mode":"cycling","name":"Straße","maneuver":{"location":[11.5700,48.1400],"type":"depart"}},{"mode":"walking","name":"Gehweg","maneuver":{"location":[11.5710,48.1410],"type":"turn"}},{"mode":"walking","name":"","maneuver":{"location":[11.5715,48.1415],"type":"arrive"}}]}],"distance":200,"duration":60}]}',
+        200,
+        headers: {'content-type': 'application/json; charset=UTF-8'},
+      );
+    }));
+
+    final route = await api.route(const [
+      LatLng(48.1400, 11.5700),
+      LatLng(48.1416, 11.5716),
+    ]);
+
+    expect(route.points, const [
+      LatLng(48.1400, 11.5700),
+      LatLng(48.1410, 11.5710),
+    ]);
+    expect(route.destinationConnector, const [
+      LatLng(48.1410, 11.5710),
+      LatLng(48.1415, 11.5715),
+      LatLng(48.1416, 11.5716),
+    ]);
+    expect(route.maneuvers, hasLength(1));
+    expect(route.maneuvers.single.type, 'depart');
+  });
+
   test('response with error message, route should throw ApiException',
       () async {
     //Given

--- a/test/ui/map/map_overlay_accessibility_test.dart
+++ b/test/ui/map/map_overlay_accessibility_test.dart
@@ -58,6 +58,34 @@ void main() {
     expect(tester.getSize(button), const Size.square(56));
   });
 
+  testWidgets('route edit and refresh buttons have explicit labels',
+      (tester) async {
+    final model = MapScreenViewModel(store: _MemorySettingsStore())
+      ..destination = Place('Ziel', const LatLng(48.15, 11.6))
+      ..route = MapRoute(
+        CycleRoute(const [], 4200, 1200),
+        MapRouteState.SHOWN,
+      );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MapNavigationHeaderBar(
+            model: model,
+            onRefreshRoute: () async {},
+            onEditRoute: () {},
+            onStartNavigation: () async {},
+            onToggleVoiceGuidance: () {},
+            onEndRoute: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Route bearbeiten'), findsOneWidget);
+    expect(find.bySemanticsLabel('Route neu berechnen'), findsOneWidget);
+  });
+
   testWidgets('route stats share a full row above the action buttons',
       (tester) async {
     final model = MapScreenViewModel(store: _MemorySettingsStore())

--- a/test/ui/map/map_screen_model_test.dart
+++ b/test/ui/map/map_screen_model_test.dart
@@ -21,6 +21,22 @@ void main() {
     expect(result, isFalse);
     expect(model.loading, isFalse);
     expect(model.initialLoadComplete, isTrue);
+    expect(model.initialRatingsLoadFailed, isTrue);
+  });
+
+  test('offers retry when only the bundled fallback was loaded', () async {
+    final model = MapScreenViewModel(
+      store: _MemorySettingsStore(),
+      munichwaysApi: _FallbackOnlyMunichwaysApi(),
+    );
+
+    final result = await model.refreshRadlnetze(
+      requestTimeout: const Duration(milliseconds: 20),
+    );
+
+    expect(result, isFalse);
+    expect(model.loading, isFalse);
+    expect(model.initialRatingsLoadFailed, isTrue);
   });
 }
 
@@ -32,6 +48,21 @@ class _StalledMunichwaysApi extends MunichwaysApi {
       StreamController<Set<MPolyline>>()
           .stream
           .timeout(responseTimeout ?? const Duration(seconds: 6));
+
+  @override
+  Future<Map<String, StreetDetails>> getStreetDetails() async => {};
+}
+
+class _FallbackOnlyMunichwaysApi extends MunichwaysApi {
+  @override
+  Stream<Set<MPolyline>> getRadlvorrangnetzUpdates({
+    Duration? responseTimeout,
+  }) async* {
+    yield <MPolyline>{};
+    await Completer<void>().future.timeout(
+          responseTimeout ?? const Duration(seconds: 6),
+        );
+  }
 
   @override
   Future<Map<String, StreetDetails>> getStreetDetails() async => {};

--- a/test/ui/map/voice_guidance_test.dart
+++ b/test/ui/map/voice_guidance_test.dart
@@ -360,4 +360,88 @@ void main() {
       'Sie haben das Ziel erreicht.',
     );
   });
+
+  test('keeps maneuvers in route order on an overlapping return section', () {
+    const junction = LatLng(48.1400, 11.5710);
+    const intermediate = LatLng(48.1400, 11.5720);
+    const destination = LatLng(48.1400, 11.5690);
+    final guidance = VoiceGuidance()
+      ..setRoute(CycleRoute(
+        const [start, junction, intermediate, junction, destination],
+        300,
+        70,
+        maneuvers: const [
+          RouteManeuver(
+            location: junction,
+            type: 'turn',
+            modifier: 'right',
+          ),
+          RouteManeuver(location: intermediate, type: 'arrive'),
+          RouteManeuver(
+            location: junction,
+            type: 'turn',
+            modifier: 'left',
+          ),
+          RouteManeuver(location: destination, type: 'arrive'),
+        ],
+      ));
+
+    expect(
+      guidance.update(intermediate, english: false),
+      'Sie haben das Zwischenziel erreicht.',
+    );
+    expect(
+      guidance.display(junction, english: false)?.text,
+      'Jetzt links',
+    );
+  });
+
+  test('does not reach the final destination before an overlapping stop', () {
+    const intermediate = LatLng(48.1400, 11.5720);
+    final guidance = VoiceGuidance()
+      ..setRoute(CycleRoute(
+        const [start, intermediate, start],
+        300,
+        70,
+        maneuvers: const [
+          RouteManeuver(location: intermediate, type: 'arrive'),
+          RouteManeuver(location: start, type: 'arrive'),
+        ],
+      ));
+
+    expect(guidance.update(start, english: false), isNull);
+    expect(
+      guidance.update(intermediate, english: false),
+      'Sie haben das Zwischenziel erreicht.',
+    );
+    expect(
+      guidance.update(start, english: false),
+      'Sie haben das Ziel erreicht.',
+    );
+  });
+
+  test('disables directions for a route overlapping around a stop', () {
+    const intermediate = LatLng(48.1400, 11.5720);
+    final guidance = VoiceGuidance();
+    guidance.setRoute(
+      CycleRoute(
+        const [start, beforeTurn, intermediate, beforeTurn, end],
+        300,
+        70,
+      ),
+      intermediateDestinationNames: const ['Zwischenziel'],
+    );
+
+    expect(
+      guidance.display(start, english: false)?.text,
+      'Keine Abbiegehinweise bei überlappendem Hin- und Rückweg',
+    );
+    expect(
+      guidance.update(start, english: false),
+      'Hin- und Rückweg überlappen. Keine Abbiegehinweise. '
+      'Bitte der Route auf der Karte folgen.',
+    );
+    expect(guidance.update(start, english: false), isNull);
+    expect(guidance.update(intermediate, english: false), isNull);
+  });
 }

--- a/test/ui/place_search/place_search_body_test.dart
+++ b/test/ui/place_search/place_search_body_test.dart
@@ -281,7 +281,87 @@ void main() {
         tester.getTopLeft(find.text('(Suchverlauf löschen)')).dy;
 
     expect(clearButtonTop, greaterThan(headingTop));
-    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsNWidgets(2));
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('renames a recent destination with the edit button',
+      (tester) async {
+    final store = FakeRecentSearchesStore([
+      Place('Doctor Drooly', const LatLng(48.128, 11.557)),
+    ]);
+    final model = PlaceSearchScreenViewModel(recentSearchesRepo: store);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: PlaceSearchBody(model: model)),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byTooltip('Umbenennen'), findsOneWidget);
+    await tester.tap(find.byTooltip('Umbenennen'));
+    await tester.pumpAndSettle();
+    expect(find.text('Ziel umbenennen'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField), 'Tierarzt');
+    await tester.tap(find.text('Speichern'));
+    await tester.pumpAndSettle();
+
+    expect(model.recentSearches.single.displayName, 'Tierarzt');
+    expect(store.storedPlaces?.single.displayName, 'Tierarzt');
+  });
+
+  testWidgets('removes a single recent destination with its delete button',
+      (tester) async {
+    final home = Place('Home', const LatLng(48.2, 11.6));
+    final work = Place('Work', const LatLng(48.1, 11.5));
+    final store = FakeRecentSearchesStore([home, work]);
+    final favoritesStore = FakeRecentSearchesStore([home]);
+    final model = PlaceSearchScreenViewModel(
+      recentSearchesRepo: store,
+      favoritesRepo: favoritesStore,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: PlaceSearchBody(model: model)),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byTooltip('Route berechnen'), findsNWidgets(3));
+    await tester.tap(find.byTooltip('Endgültig löschen').first);
+    await tester.pump();
+
+    expect(model.recentSearches, [work]);
+    expect(model.favoritePlaces, isEmpty);
+    expect(store.storedPlaces, [work]);
+    expect(favoritesStore.storedPlaces, isEmpty);
+  });
+
+  testWidgets('favorite star only disables favorite status', (tester) async {
+    final home = Place('Home', const LatLng(48.2, 11.6));
+    final recentStore = FakeRecentSearchesStore([home]);
+    final favoritesStore = FakeRecentSearchesStore([home]);
+    final model = PlaceSearchScreenViewModel(
+      recentSearchesRepo: recentStore,
+      favoritesRepo: favoritesStore,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: PlaceSearchBody(model: model)),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Favorit entfernen').first);
+    await tester.pump();
+
+    expect(model.favoritePlaces, isEmpty);
+    expect(model.recentSearches, [home]);
+    expect(favoritesStore.storedPlaces, isEmpty);
+    expect(recentStore.storedPlaces, isNull);
   });
 }


### PR DESCRIPTION
https://github.com/MunichWays/munich-ways-app/issues/164

- Headerleiste
- Adressanzeige Formatierung
- Favoriten und Letzte Ziele verfeinern
- letzte Meter abseits von erlaubten Wegen gestrichelt
- Routen mit Zwischenzielen und überlappenden Hin- und Rückwegen

- "keine Ansage..' rauszoomen
- Standort deaktiviert während App läuft
- Bewertungen beim Erststart fehlen
- Warnungen Google Play Console