### PR TITLE
Add GitHub Actions workflow for iOS TestFlight releases

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,45 @@
+name: iOS TestFlight Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  beta:
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.0.1'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.8'
+          channel: stable
+
+      - name: Set up Ruby (fastlane/CocoaPods)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.10'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: flutter pub get
+        run: flutter pub get
+
+      - name: fastlane beta
+        working-directory: ios
+        env:
+          CI: 'true'
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          IOS_DIST_CERT_P12_PASSWORD: ${{ secrets.IOS_DIST_CERT_P12_PASSWORD }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT_BASE64: ${{ secrets.ASC_KEY_CONTENT_BASE64 }}
+          GEOAPIFY_API_KEY: ${{ secrets.GEOAPIFY_API_KEY }}
+        run: bundle exec fastlane beta

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,6 +1,9 @@
 skip_docs
 
+require "base64"
 require "fileutils"
+require "securerandom"
+require "tmpdir"
 
 default_platform(:ios)
 
@@ -47,9 +50,38 @@ platform :ios do
     #     directly and would otherwise archive whatever version was cached from the last `flutter
     #     build`/`flutter run`, silently diverging from pubspec.yaml.
     repo_root = File.expand_path("../..", __dir__)
-    sh(%(cd "#{repo_root}" && flutter build ios --release --no-codesign))
+    geoapify_key = ENV["GEOAPIFY_API_KEY"].to_s
+    dart_defines = geoapify_key.empty? ? "" : %( --dart-define=GEOAPIFY_API_KEY="#{geoapify_key}")
+    sh(%(cd "#{repo_root}" && flutter build ios --release --no-codesign#{dart_defines}))
 
-    # 0b) Register ASC API key (if present) so cert/sigh/upload_to_testflight all use it
+    # 0b) A dev machine's login keychain already holds the distribution certificate, so
+    #     `cert` below just finds it. A GitHub Actions runner starts with an empty keychain
+    #     each run, so import IOS_DIST_CERT_P12_BASE64 into a throwaway keychain first —
+    #     otherwise `cert` (force: false) sees the cert already exists in the Developer
+    #     Portal, but has no private key on disk to install it with, and fails.
+    if ENV["CI"] == "true"
+      keychain_password = SecureRandom.hex(16)
+      create_keychain(
+        name: "ci-signing",
+        password: keychain_password,
+        default_keychain: true,
+        unlock: true,
+        timeout: 3600,
+        lock_when_sleeps: false
+      )
+      p12_base64 = ENV["IOS_DIST_CERT_P12_BASE64"].to_s
+      UI.user_error!("Set IOS_DIST_CERT_P12_BASE64 (and IOS_DIST_CERT_P12_PASSWORD) for CI signing.") if p12_base64.empty?
+      p12_path = File.join(Dir.mktmpdir, "dist_cert.p12")
+      File.binwrite(p12_path, Base64.decode64(p12_base64))
+      import_certificate(
+        certificate_path: p12_path,
+        certificate_password: ENV["IOS_DIST_CERT_P12_PASSWORD"].to_s,
+        keychain_name: "ci-signing",
+        keychain_password: keychain_password
+      )
+    end
+
+    # 0c) Register ASC API key (if present) so cert/sigh/upload_to_testflight all use it
     #    instead of prompting for an Apple ID login. Must run before cert/sigh.
     asc_key = app_store_connect_api_key_from_env
     # 1) Ensure distribution certificate exists in keychain


### PR DESCRIPTION
## Zusammenfassung
  - `.github/workflows/ios-testflight.yml`: neuer manuell auslösbarer Workflow
    (`workflow_dispatch`) — richtet auf einem macOS-Runner Xcode 26, Flutter
    und Ruby/fastlane ein und führt anschließend die bestehende `fastlane beta`
    Lane aus.
  - `ios/fastlane/Fastfile`: wenn `CI=true` gesetzt ist, wird das
    Distribution-Zertifikat (als .p12, aus den Secrets
    `IOS_DIST_CERT_P12_BASE64`/`IOS_DIST_CERT_P12_PASSWORD`) in ein temporäres
    Keychain importiert, bevor `cert` läuft — ein frischer Runner hat (anders
    als der lokale Login-Keychain auf dem Mac) noch keine Signing-Identität
    installiert.
  - `ios/fastlane/Fastfile`: `GEOAPIFY_API_KEY` wird jetzt auch beim
    `flutter build ios` durchgereicht (analog zum bestehenden
    Android-Release-Workflow), da ein frischer CI-Checkout kein gecachtes
    `Generated.xcconfig` mit bereits gebackenen Dart-Defines hat.
    
  ## Benötigte Repo-Secrets (bereits gesetzt)
  - `IOS_DIST_CERT_P12_BASE64`, `IOS_DIST_CERT_P12_PASSWORD`
  - `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_CONTENT_BASE64`
  - `GEOAPIFY_API_KEY`
  
  ## Testplan
  - [ ] Workflow einmal manuell über „Run workflow" im Actions-Tab auslösen
  - [ ] Prüfen, dass Zertifikatsimport, Signing und Upload zu TestFlight
        erfolgreich durchlaufen
  - [ ] Build in App Store Connect / TestFlight sichtbar

  🤖 Generated with [Claude Code](https://claude.com/claude-code)