### PR TITLE
Fix CI cert lookup: point cert action at the ci-signing keychain

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -85,10 +85,13 @@ platform :ios do
     #    instead of prompting for an Apple ID login. Must run before cert/sigh.
     asc_key = app_store_connect_api_key_from_env
     # 1) Ensure distribution certificate exists in keychain
-    cert(
-      development: false,
-      force: false
-    )
+    # `cert`'s own keychain_path param defaults to login.keychain-db regardless of which
+    # keychain create_keychain/import_certificate above set up — it doesn't follow the OS
+    # default keychain. In CI, point it at ci-signing explicitly, or it won't find the
+    # cert we just imported there and will (needlessly) generate a new one instead.
+    cert_params = { development: false, force: false }
+    cert_params[:keychain_path] = "ci-signing" if ENV["CI"] == "true"
+    cert(cert_params)
     # 2) Create/download App Store provisioning profile
     sigh(
       app_identifier: "com.munichways.app",


### PR DESCRIPTION
## Summary
`cert`'s own `keychain_path` param defaults to `login.keychain-db` regardless of which keychain `create_keychain`/`import_certificate` set up as the OS default keychain. In CI this meant `cert` couldn't find the certificate we'd just imported into `ci-signing`, and (since `force: false`) generated a brand-new, unneeded distribution certificate instead of reusing the existing one.

Fix: explicitly pass `keychain_path: "ci-signing"` to `cert` when `CI=true`.

## Test plan
- [ ] Re-run "iOS TestFlight Release" workflow after merge, confirm `cert` finds the existing certificate instead of creating a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)